### PR TITLE
🚨 Update ktlint config to allow wildcard import

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.{kt,kts}]
+disabled_rules = no-wildcard-imports


### PR DESCRIPTION
IntelliJ에서 모든 package를 import하는 경우 자동으로 wildcard로 변환해주는데, ktlint 기본 설정에서는 이를 허용하지 않아 자주 충돌이 일어났습니다. 따라서 이를 허용하도록 설정을 변경하였습니다.