### PR TITLE
Hotfix/Question Tag 버그 해결

### DIFF
--- a/src/main/kotlin/com/wafflestudio/team2/jisik2n/core/question/dto/QuestionDto.kt
+++ b/src/main/kotlin/com/wafflestudio/team2/jisik2n/core/question/dto/QuestionDto.kt
@@ -25,7 +25,7 @@ data class QuestionDto(
                 id = this.id,
                 title = this.title,
                 content = this.content,
-                tag = this.tag.split("/"),
+                tag = if (this.tag == "") listOf() else this.tag.split("/"),
                 username = this.user.username,
                 profileImagePath = this.user.profileImage,
                 photos = this.photos

--- a/src/main/kotlin/com/wafflestudio/team2/jisik2n/core/question/service/QuestionService.kt
+++ b/src/main/kotlin/com/wafflestudio/team2/jisik2n/core/question/service/QuestionService.kt
@@ -108,7 +108,6 @@ class QuestionServiceImpl(
             photoService.deletePhotos(it.photos)
         }
 
-
         questionRepository.delete(questionEntity)
     }
 }

--- a/src/test/kotlin/com/wafflestudio/team2/jisik2n/core/question/QuestionServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/team2/jisik2n/core/question/QuestionServiceTest.kt
@@ -38,6 +38,7 @@ internal class QuestionServiceTest @Autowired constructor(
         assertThat(questionDto.title).isEqualTo(question.title)
         assertThat(questionDto.content).isEqualTo(question.content)
         assertThat(questionDto.username).isEqualTo(question.user.username)
+        assertThat(questionDto.tag.size).isEqualTo(2)
     }
 
     @Test
@@ -63,6 +64,24 @@ internal class QuestionServiceTest @Autowired constructor(
         assertThat(question.title).isEqualTo(createQuestionRequest.title)
         assertThat(question.content).isEqualTo(createQuestionRequest.content)
         assertThat(question.tag).isEqualTo(createQuestionRequest.tag)
+    }
+
+    @Test
+    fun `Create Question - Empty tag`() {
+        val createQuestionRequest = CreateQuestionRequest(
+            title = "test",
+            content = "test",
+            tag = listOf(),
+            photos = listOf(),
+        )
+        val user = userTestHelper.createTestUser(1)
+
+        val question = questionService.createQuestion(createQuestionRequest, user)
+
+        assertThat(questionRepository.findAll()).hasSize(1)
+        assertThat(question.title).isEqualTo(createQuestionRequest.title)
+        assertThat(question.content).isEqualTo(createQuestionRequest.content)
+        assertThat(question.tag.size).isEqualTo(0)
     }
 
 //     @Test


### PR DESCRIPTION
- tag 를 입력하지 않았을 때 질문 정보를 받으면 빈 문자열 하나를 가진 배열이 반환되는 버그 해결