### PR TITLE
🚑️ Change ProfileImage to save path(dir) of the image, not url

### DIFF
--- a/src/main/kotlin/com/wafflestudio/team2/jisik2n/core/user/service/UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/team2/jisik2n/core/user/service/UserService.kt
@@ -10,6 +10,7 @@ import com.wafflestudio.team2.jisik2n.core.answer.database.AnswerRepository
 import com.wafflestudio.team2.jisik2n.core.question.database.QuestionRepository
 import com.wafflestudio.team2.jisik2n.core.user.database.*
 import com.wafflestudio.team2.jisik2n.core.user.dto.*
+import com.wafflestudio.team2.jisik2n.external.s3.service.S3Service
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
@@ -60,6 +61,7 @@ class UserServiceImpl(
     private val questionRepository: QuestionRepository,
     private val answerRepository: AnswerRepository,
     private val passwordEncoder: PasswordEncoder,
+    private val s3Service: S3Service,
 ) : UserService {
 
     override fun signup(signupRequest: SignupRequest): AuthToken {
@@ -239,9 +241,10 @@ class UserServiceImpl(
             }
         }
 
-        userEntity.profileImage = userRequest.profileImage
+        val profileImagePath = userRequest.profileImage ?. let { s3Service.getFilenameFromUrl(it) }
+        userEntity.profileImage = profileImagePath
         userEntity.isMale = userRequest.isMale
-        return UserResponse(userEntity.username, userEntity.profileImage, userEntity.isMale)
+        return UserResponse(userEntity.username, userRequest.profileImage, userEntity.isMale)
     }
 
     @Transactional


### PR DESCRIPTION
- Profile Image를 question, answer에서 가져올 때 url을 중복되게 반환해주는 오류를 해결하기 위한 수정사항입니다.
  - 기존 question, answer에서 사진을 저장하는 방식과 통일시키기 위해 위와 같이 수정하였습니다.