### PR TITLE
:ambulance: 카카오 로그인 후 프로필 수정 핫픽스

### DIFF
--- a/src/main/kotlin/com/wafflestudio/team2/jisik2n/core/user/service/UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/team2/jisik2n/core/user/service/UserService.kt
@@ -163,37 +163,37 @@ class UserServiceImpl(
                 null
             }
 
-        val kakaoUsername = "kakao-$username"
-        if (userRepository.findByUsername(kakaoUsername) == null) {
-            userRepository.save(UserEntity(kakaoUsername, snsId, kakaoUsername, null, LocalDateTime.now(), gender, null, true))
+        val kakaoUid = "kakao-$username"
+        if (userRepository.findByUid(kakaoUid) == null) {
+            userRepository.save(UserEntity(kakaoUid, snsId, kakaoUid, null, LocalDateTime.now(), gender, null, true))
 
-            val accessToken = authTokenService.generateAccessTokenByUid(kakaoUsername)
-            val refreshToken = authTokenService.generateRefreshTokenByUid(kakaoUsername)
+            val accessToken = authTokenService.generateAccessTokenByUid(kakaoUid)
+            val refreshToken = authTokenService.generateRefreshTokenByUid(kakaoUid)
 
-            val tokenEntity = TokenEntity.of(accessToken, refreshToken, kakaoUsername)
+            val tokenEntity = TokenEntity.of(accessToken, refreshToken, kakaoUid)
 
             tokenRepository.save(tokenEntity)
 
-            return LoginResponse.of(tokenEntity, kakaoUsername)
+            return LoginResponse.of(tokenEntity, kakaoUid)
         } else {
-            val userEntity = userRepository.findByUsername(kakaoUsername)!!
+            val userEntity = userRepository.findByUid(kakaoUid)!!
             if (userEntity.isActive == false) {
                 throw Jisik2n403("탈퇴한 회원의 아이디입니다")
             }
-            val accessToken = authTokenService.generateAccessTokenByUid(kakaoUsername)
+            val accessToken = authTokenService.generateAccessTokenByUid(kakaoUid)
 
             val lastLogin = LocalDateTime.from(authTokenService.getCurrentIssuedAt(accessToken))
             userEntity.lastLogin = lastLogin
 
-            val tokenEntity = tokenRepository.findByKeyUid(kakaoUsername)!!
+            val tokenEntity = tokenRepository.findByKeyUid(kakaoUid)!!
             tokenEntity.accessToken = accessToken
 
             if (authTokenService.getCurrentExpiration(tokenEntity.refreshToken) < LocalDateTime.now()) {
-                val refreshToken = authTokenService.generateRefreshTokenByUid(kakaoUsername)
+                val refreshToken = authTokenService.generateRefreshTokenByUid(kakaoUid)
                 tokenEntity.refreshToken = refreshToken
             }
 
-            return LoginResponse.of(tokenEntity, kakaoUsername)
+            return LoginResponse.of(tokenEntity, userEntity.username)
         }
     }
 


### PR DESCRIPTION
지금 카카오 유저가 프로필 수정 -> 로그아웃 -> 재로그인 하면 로그인 실패가 뜨는 오류가 있습니다.
해당 오류는 저희가 db에서 유저를 찾을 때 findByUsername으로 하고 있었는데,
username이 바뀌니까 유저는 null로 나오는데 uid는 중복된 값이 있어서 저장도 못하고 "중복된 값이 있습니다."라는 오류를 띄우고 있어요.

이에 따라 username이 바뀌어도 uid는 바뀌지 않기 때문에 findByUsername을 findByUid로 변경했어요.
그리고 kakaoUsername이라는 변수를 kakaoUid라고 바꿨는데, 
username은 db에서 변경이 가능하지만 uid는 변경이 되지 않고, 그래서 정체성에 더 맞는 변수명은 kakaoUid라고 생각하기 때문입니다.
변경사항이 많아보이지만 대부분 kakaoUsername을 kakaoUid로 변경한 것입니다.

딱 하나 아닌게 있는데, 196째 줄에 나타나는 userEntity.username은 kakaoUid가 아니라 변경된 username을 반환해야 하기 때문에 다음과 같이 바꿨습니다.
확인해보시고 pr 부탁드려요.